### PR TITLE
Add automated deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cloudflare/wrangler-action@v2
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          command: pages deploy ./ --project-name=reading-tech-folk --branch=${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 [https://readingtechfolk.org/](https://readingtechfolk.org/)
+
+## Deployment
+
+The repository includes a GitHub Actions workflow that deploys the site to Cloudflare Pages. Deployments run automatically on every push to `main` and preview builds are created for each pull request.
+
+Add these secrets to your repository configuration so the workflow can authenticate with Cloudflare:
+
+- `CF_API_TOKEN` – API token used by the Wrangler action.
+- `CF_ACCOUNT_ID` – Cloudflare account identifier required by the action.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy via Cloudflare Pages
- document required secrets and automatic deployment preview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d2d1b690c8324996562a198e6a7a2