### PR TITLE
Fix external link attributes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@
         <a
           href="https://www.readingbiscuitfactory.co.uk/about-us"
           target="_blank"
+          rel="noopener noreferrer"
           >The Biscuit Factory</a
         >
         in Reading


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to the Biscuit Factory link

## Testing
- `npx htmlhint src/index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e63d2a47483249ad3738c1ce6e1a6