### PR TITLE
Update next event date

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,7 @@
     <main>
       <h2>Next Event</h2>
       <p>
-        The next event is on Wednesday the 25th of June 2025, 7pm, at
+        The next event is on Wednesday the 23rd of July 2025, 7pm, at
         <a
           href="https://www.readingbiscuitfactory.co.uk/about-us"
           target="_blank"


### PR DESCRIPTION
## Summary
- update event date on homepage to July 23, 2025

## Testing
- `npx htmlhint src/index.html` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6864188132788324b4e1e7fe16355cd7